### PR TITLE
Update vergelijker pages to Adviesneutraal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Contractvergelijkers Landing Pages
+# Adviesneutraal Landing Pages
 
 Professional landing pages for energy comparison services in the Netherlands, targeting Google Ads campaigns for branded keywords.
 
 ## Project Overview
 
-**Business**: Contractvergelijkers - Energy comparison service with 200+ call center representatives  
+**Business**: Adviesneutraal - Energy comparison and advice service with 200+ call center representatives  
 **Target Market**: Netherlands  
 **Phone Number**: +31 85 087 2183  
 **Campaign Strategy**: Target branded keywords of major Dutch energy providers  
@@ -141,7 +141,7 @@ Professional landing pages for energy comparison services in the Netherlands, ta
 
 ### Production Setup
 1. Upload all files to web server
-2. Configure domain: `contractvergelijkers.nl`
+2. Configure domain: `adviesneutraal.nl`
 3. Set up SSL certificate
 4. Configure Google Analytics tracking
 5. Submit sitemap to Google Search Console
@@ -178,4 +178,4 @@ Professional landing pages for energy comparison services in the Netherlands, ta
 
 ---
 
-*This landing page system is designed to capture high-intent traffic from users searching for energy provider customer service, converting them into phone calls for the Contractvergelijkers call center.*
+*This landing page system is designed to capture high-intent traffic from users searching for energy provider customer service, converting them into phone calls for the Adviesneutraal call center.*

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -74,16 +74,16 @@ export default function Home() {
   return (
     <>
       <Head>
-        <title>Energie Informatie 2025 - Contractvergelijkers | Vergelijk ALLE energieleveranciers | +31 85 087 2183</title>
-        <meta name="description" content="🆕 Energie Informatie 2025: Vergelijk ALLE 50+ energieleveranciers in Nederland. Onafhankelijk advies, gratis service, bespaar tot €500 per jaar. Bel: +31 85 087 2183" />
+        <title>Energie Informatie 2025 - Adviesneutraal | Vergelijk ALLE energieleveranciers | +31 85 087 2183</title>
+        <meta name="description" content="🆕 Energie Informatie 2025: Vergelijk ALLE 50+ energieleveranciers in Nederland. Onafhankelijk advies van Adviesneutraal, gratis service, bespaar tot €500 per jaar. Bel: +31 85 087 2183" />
         <meta name="keywords" content="energie vergelijken 2025, energieleverancier vergelijken, klantenservice energie, goedkoopste energie, groene energie, energie overstappen" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
         
         {/* Open Graph */}
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://contractvergelijkers.nl/" />
-        <meta property="og:title" content="Energie Informatie 2025 - Contractvergelijkers" />
+        <meta property="og:url" content="https://adviesneutraal.nl/" />
+        <meta property="og:title" content="Energie Informatie 2025 - Adviesneutraal" />
         <meta property="og:description" content="Vergelijk ALLE 50+ energieleveranciers in Nederland. Onafhankelijk advies, gratis service, bespaar tot €500 per jaar." />
       </Head>
 
@@ -91,7 +91,7 @@ export default function Home() {
         {/* Navigation */}
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
                       <div className="flex items-center">
-              <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers Logo" className="h-16 md:h-18 w-auto" />
+              <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal Logo" className="h-16 md:h-18 w-auto" />
             </div>
                       <div className="hidden md:flex space-x-6 items-center">
               <Link href="/vergelijker" className="text-white hover:text-green-200 transition-colors">
@@ -172,7 +172,7 @@ export default function Home() {
         {/* Trust Indicators - Enhanced */}
         <section className="max-w-7xl mx-auto px-6 py-16">
           <h2 className="text-3xl font-bold text-white text-center mb-12">
-            Waarom 10.000+ Nederlanders kiezen voor Contractvergelijkers?
+            Waarom 10.000+ Nederlanders kiezen voor Adviesneutraal?
           </h2>
           <div className="grid md:grid-cols-5 gap-6">
             <div className="bg-white/10 backdrop-blur-lg rounded-xl p-6 text-center">
@@ -369,7 +369,7 @@ export default function Home() {
         {/* About Section - Enhanced */}
         <section id="over-ons" className="max-w-7xl mx-auto px-6 py-16">
           <div className="bg-white/10 backdrop-blur-lg rounded-xl p-8 border border-white/20">
-            <h2 className="text-3xl font-bold text-white mb-6">Over Contractvergelijkers</h2>
+            <h2 className="text-3xl font-bold text-white mb-6">Over Adviesneutraal</h2>
             <div className="grid md:grid-cols-2 gap-8">
               <div className="space-y-6">
                 <p className="text-blue-100 text-lg leading-relaxed">
@@ -574,14 +574,52 @@ export default function Home() {
           </div>
         </section>
 
+        {/* Transparency & Compliance Section */}
+        <section id="transparantie" className="max-w-7xl mx-auto px-6 py-16">
+          <div className="bg-white/10 backdrop-blur-lg rounded-2xl p-8 border border-white/20">
+            <h2 className="text-3xl font-bold text-white mb-6">Transparantie & Onafhankelijkheid</h2>
+            <div className="grid md:grid-cols-2 gap-8 text-blue-100">
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Wie zijn wij?</h3>
+                  <p>Adviesneutraal is een onafhankelijk adviesplatform. Wij zijn geen energieleverancier en beheren geen klantdossiers van leveranciers.</p>
+                </div>
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Wat doen wij?</h3>
+                  <p>Wij vergelijken alle Nederlandse energieleveranciers (vast, variabel, dynamisch; groen en traditioneel) en geven neutraal advies passend bij uw situatie.</p>
+                </div>
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Hoe verdienen wij?</h3>
+                  <p>Onze dienst is gratis voor consumenten. Bij een overstap kunnen wij een vergoeding ontvangen van een leverancier of partner. Dit beïnvloedt ons advies niet.</p>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Methodologie</h3>
+                  <p>Wij wegen o.a. prijs, contractduur, tariefzekerheid, duurzaamheid (GvO), voorwaarden en klanttevredenheid. Persoonlijke factoren (verbruik, postcode) bepalen de best passende opties.</p>
+                </div>
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Privacy & AVG</h3>
+                  <p>Wij verwerken alleen noodzakelijke gegevens volgens de AVG. Wij verkopen geen persoonsgegevens. Zie onze privacyverklaring voor details.</p>
+                </div>
+                <div>
+                  <h3 className="text-white font-semibold mb-1">Bereikbaarheid</h3>
+                  <p>Telefonisch bereikbaar Ma–Vr: 09:00–20:30. Voor vragen of klachten: info@adviesneutraal.nl.</p>
+                </div>
+              </div>
+            </div>
+            <p className="text-blue-200 text-sm mt-6">Adviesneutraal vergelijkt de volledige Nederlandse markt voor consumenten. Wij zijn onafhankelijk en werken transparant.</p>
+          </div>
+        </section>
+
         {/* Footer */}
         <footer className="border-t border-white/20 mt-20">
           <div className="max-w-7xl mx-auto px-6 py-8">
             <div className="grid md:grid-cols-3 gap-8 mb-8">
                              <div>
-                                   <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers Logo" className="h-14 md:h-16 w-auto mb-4" />
+                                   <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal Logo" className="h-14 md:h-16 w-auto mb-4" />
                  <p className="text-blue-200 mb-4">
-                   Het grootste onafhankelijke energievergelijkingsplatform van Nederland.
+                   Het grootste onafhankelijke energie-adviesplatform van Nederland.
                  </p>
                  <p className="text-green-400 font-bold">
                    📞 {phoneNumber}
@@ -607,10 +645,8 @@ export default function Home() {
               </div>
             </div>
             <div className="border-t border-white/20 pt-8 text-center text-blue-200">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
-              <p className="mt-2 text-sm">
-                Onafhankelijk energievergelijker • Geen verborgen kosten • 100% gratis service
-              </p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
+              <p className="mt-2 text-sm">Onafhankelijk energie-advies • Geen verborgen kosten • 100% gratis service</p>
             </div>
           </div>
         </footer>

--- a/pages/klantenservice.tsx
+++ b/pages/klantenservice.tsx
@@ -52,8 +52,8 @@ export default function Klantenservice() {
   return (
     <>
       <Head>
-        <title>Klantenservice | Contractvergelijkers Advieslijn</title>
-        <meta name="description" content="Klantenservice Contractvergelijkers: onafhankelijk advies en tarieven vergelijken. Wij helpen met vragen en overstappen. Bel direct." />
+        <title>Klantenservice | Adviesneutraal Advieslijn</title>
+        <meta name="description" content="Klantenservice Adviesneutraal: onafhankelijk advies en tarieven vergelijken. Wij helpen met vragen en overstappen. Bel direct." />
         <meta name="keywords" content="klantenservice energie, energieleverancier telefoonnummer, energie vergelijken, onafhankelijk advies, overstappen energie" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -95,7 +95,7 @@ export default function Klantenservice() {
                   <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-gray-900">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-gray-900">Adviesneutraal</span>
                 </div>
               </Link>
               <div className="flex items-center space-x-4">
@@ -113,7 +113,7 @@ export default function Klantenservice() {
           <div className="max-w-4xl mx-auto px-6 text-center">
             <div className="mb-8">
               <h1 className="text-3xl md:text-5xl font-bold text-gray-900 mb-4 leading-tight">
-                <span className="text-blue-600">Klantenservice Contractvergelijkers</span>
+                <span className="text-blue-600">Klantenservice Adviesneutraal</span>
                 <br />
                 <span className="text-2xl md:text-3xl text-gray-700">Direct hulp & onafhankelijk energie-advies</span>
               </h1>
@@ -151,7 +151,7 @@ export default function Klantenservice() {
 
             {/* Main CTA */}
             <div className="bg-blue-600 text-white p-8 rounded-xl mb-8">
-              <h2 className="text-2xl font-bold mb-4">Direct contact met Contractvergelijkers Klantenservice</h2>
+              <h2 className="text-2xl font-bold mb-4">Direct contact met Adviesneutraal Klantenservice</h2>
               <p className="text-blue-100 mb-6">
                 Bel voor onafhankelijk energie-advies en vergelijking van tarieven. Wij zijn geen onderdeel van energieleveranciers en behandelen geen klantdossiers van providers.
               </p>
@@ -486,7 +486,7 @@ export default function Klantenservice() {
               <div className="text-center p-6 bg-blue-50 rounded-xl border border-blue-200">
                 <div className="text-4xl mb-4">💬</div>
                 <h3 className="text-xl font-bold text-gray-900 mb-2">Duidelijk Overzicht</h3>
-                <p className="text-gray-600 mb-4">"Door over te stappen via Contractvergelijkers heb ik nu een duidelijk overzicht en passende deal."
+                <p className="text-gray-600 mb-4">"Door over te stappen via Adviesneutraal heb ik nu een duidelijk overzicht en passende deal."
                 </p>
                 <div className="text-sm text-gray-500">- Sarah, Amsterdam</div>
               </div>
@@ -525,7 +525,7 @@ export default function Klantenservice() {
               📞 Heeft u Hulp Nodig?
             </h2>
             <p className="text-blue-100 text-lg mb-8">
-              Onze klantenservice van Contractvergelijkers staat klaar met onafhankelijk advies over uw energievraag.
+              Onze klantenservice van Adviesneutraal staat klaar met onafhankelijk advies over uw energievraag.
             </p>
             
             <a 
@@ -537,7 +537,7 @@ export default function Klantenservice() {
             </a>
             
             <p className="text-blue-100 text-sm mt-4">
-              Wij zijn de klantenservice van contractvergelijkers.nl (onafhankelijke advieslijn) en niet de officiële klantenservice van energieleveranciers. Voor contract- en factuurzaken bij uw huidige provider kunt u rechtstreeks bij uw leverancier terecht.
+              Wij zijn de klantenservice van adviesneutraal.nl (onafhankelijke advieslijn) en niet de officiële klantenservice van energieleveranciers. Voor contract- en factuurzaken bij uw huidige provider kunt u rechtstreeks bij uw leverancier terecht.
             </p>
           </div>
         </section>
@@ -547,7 +547,7 @@ export default function Klantenservice() {
           <div className="max-w-6xl mx-auto px-6">
             <div className="grid md:grid-cols-3 gap-8">
               <div>
-                <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
+                <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
                 <p className="text-gray-300 mb-4">
                   Transparant en onafhankelijk energie-advies.
                 </p>
@@ -588,7 +588,7 @@ export default function Klantenservice() {
             </div>
 
             <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
           </div>
         </footer>

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -5,14 +5,14 @@ export default function Privacy() {
   return (
     <>
       <Head>
-        <title>Privacyverklaring | Contractvergelijkers</title>
-        <meta name="description" content="Privacyverklaring van Contractvergelijkers: uitleg over waarom en hoe wij persoonsgegevens verwerken en uw AVG-rechten." />
+        <title>Privacyverklaring | Adviesneutraal</title>
+        <meta name="description" content="Privacyverklaring van Adviesneutraal: uitleg over waarom en hoe wij persoonsgegevens verwerken en uw AVG-rechten." />
       </Head>
 
       <main className="min-h-screen bg-gray-50">
         <header className="bg-white shadow-sm">
           <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-            <Link href="/" className="text-xl font-bold text-gray-900">Contractvergelijkers</Link>
+            <Link href="/" className="text-xl font-bold text-gray-900">Adviesneutraal</Link>
             <nav className="space-x-4 text-sm">
               <Link href="/klantenservice" className="text-blue-600 hover:underline">Klantenservice</Link>
             </nav>
@@ -24,18 +24,18 @@ export default function Privacy() {
 
           <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3">Inleiding</h2>
           <p className="text-gray-700 mb-6">
-            Contractvergelijkers verwerkt persoonsgegevens van haar klanten en websitebezoekers. Wij doen dit om u zo goed mogelijk te helpen en onze doelstellingen te bereiken. In dit privacy statement leggen we uit waarom en op welke manier we uw persoonsgegevens verwerken.
+            Adviesneutraal verwerkt persoonsgegevens van haar klanten en websitebezoekers. Wij doen dit om u zo goed mogelijk te helpen en onze doelstellingen te bereiken. In dit privacy statement leggen we uit waarom en op welke manier we uw persoonsgegevens verwerken.
           </p>
 
           <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3">Wie zijn wij?</h2>
           <p className="text-gray-700 mb-4">
-            Wij zijn <strong>Contractvergelijkers</strong>: adviseur op het gebied van energiezaken. Dit privacy statement ziet op al onze verwerkingen – ook indien we samen met andere partijen persoonsgegevens verwerken.
+            Wij zijn <strong>Adviesneutraal</strong>: adviseur op het gebied van energiezaken. Dit privacy statement ziet op al onze verwerkingen – ook indien we samen met andere partijen persoonsgegevens verwerken.
           </p>
           <ul className="list-disc pl-6 text-gray-700 mb-6">
-            <li>Contractvergelijkers B.V.</li>
+            <li>Adviesneutraal B.V.</li>
             <li>Adres: [Straatnaam] [Huisnummer], [Postcode] [Plaats]</li>
             <li>Telefoon: 085 087 2183</li>
-            <li>E-mail: info@contractvergelijkers.nl</li>
+            <li>E-mail: info@adviesneutraal.nl</li>
             <li>KvK: [KvK-nummer]</li>
           </ul>
 
@@ -52,7 +52,7 @@ export default function Privacy() {
           <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3">Waarom verwerken wij die persoonsgegevens?</h2>
           <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-2">Werving (marketing)</h3>
           <p className="text-gray-700 mb-4">
-            Binnen Contractvergelijkers werven wij o.a. nieuwe prospects voor interessante aanbiedingen op de energiemarkt bij verschillende leveranciers en ook nieuwe collega’s. Om met iedereen contact te onderhouden verwerken wij ook van hen contactdetails en interessegebieden indien aangegeven door de prospects. Wij geven geen persoonsgegevens door aan derde partijen, tenzij u daar ondubbelzinnige toestemming voor hebt gegeven.
+            Binnen Adviesneutraal werven wij o.a. nieuwe prospects voor interessante aanbiedingen op de energiemarkt bij verschillende leveranciers en ook nieuwe collega’s. Om met iedereen contact te onderhouden verwerken wij ook van hen contactdetails en interessegebieden indien aangegeven door de prospects. Wij geven geen persoonsgegevens door aan derde partijen, tenzij u daar ondubbelzinnige toestemming voor hebt gegeven.
           </p>
           <h3 className="text-xl font-semibold text-gray-900 mt-6 mb-2">Partneradministratie en dienstverlening</h3>
           <p className="text-gray-700 mb-4">
@@ -74,7 +74,7 @@ export default function Privacy() {
 
           <h2 className="text-2xl font-semibold text-gray-900 mt-8 mb-3">Rechten van betrokkenen</h2>
           <p className="text-gray-700 mb-4">
-            In de AVG zijn een aantal rechten opgenomen die voor iedereen gelden. Wij doen ons uiterste best om hier zo goed mogelijk aan te voldoen. Heeft u tips of opmerkingen? Laat het ons dan weten! Om van uw rechten gebruik te maken kunt u contact met ons opnemen via 085 087 2183 of <a href="mailto:info@contractvergelijkers.nl" className="text-blue-600 underline">info@contractvergelijkers.nl</a>.
+            In de AVG zijn een aantal rechten opgenomen die voor iedereen gelden. Wij doen ons uiterste best om hier zo goed mogelijk aan te voldoen. Heeft u tips of opmerkingen? Laat het ons dan weten! Om van uw rechten gebruik te maken kunt u contact met ons opnemen via 085 087 2183 of <a href="mailto:info@adviesneutraal.nl" className="text-blue-600 underline">info@adviesneutraal.nl</a>.
           </p>
           <ul className="list-disc pl-6 text-gray-700 mb-6">
             <li><strong>Informatie en inzage:</strong> u kunt inzien welke persoonsgegevens we van u verwerken en waarom.</li>
@@ -110,7 +110,7 @@ export default function Privacy() {
 
         <footer className="bg-gray-900 text-white py-10">
           <div className="max-w-5xl mx-auto px-6 flex items-center justify-between">
-            <div>© {new Date().getFullYear()} Contractvergelijkers</div>
+            <div>© {new Date().getFullYear()} Adviesneutraal</div>
             <div className="space-x-4">
               <Link href="/" className="hover:underline">Home</Link>
               <Link href="/klantenservice" className="hover:underline">Klantenservice</Link>

--- a/pages/providers/budget-energie.tsx
+++ b/pages/providers/budget-energie.tsx
@@ -8,8 +8,8 @@ export default function BudgetEnergie() {
   return (
     <>
       <Head>
-        <title>Budget Energie Informatie 2025 - Voordelige Tarieven | Contractvergelijkers</title>
-        <meta name="description" content="Budget Energie informatie 2025: Voordelige energietarieven, eenvoudige contracten en klantenservice. Vergelijk via Contractvergelijkers." />
+        <title>Budget Energie Informatie 2025 - Voordelige Contracten | Adviesneutraal</title>
+        <meta name="description" content="Budget Energie informatie 2025: Voordelige, eenvoudige contracten. Vergelijk via Adviesneutraal." />
         <meta name="keywords" content="Budget Energie tarieven 2025, goedkope energie, Budget Energie overstappen" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -18,7 +18,7 @@ export default function BudgetEnergie() {
       <main className="min-h-screen bg-gradient-to-br from-blue-600 via-green-600 to-blue-800">
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -90,7 +90,7 @@ export default function BudgetEnergie() {
         <footer className="border-t border-white/20 mt-20">
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-              Contractvergelijkers
+              Adviesneutraal
             </Link>
             <p className="text-blue-200 mt-4">
               <a href={`tel:${phoneNumber}`} className="text-green-400 hover:text-green-300 font-bold">

--- a/pages/providers/eneco.tsx
+++ b/pages/providers/eneco.tsx
@@ -8,8 +8,8 @@ export default function Eneco() {
   return (
     <>
       <Head>
-        <title>Eneco Informatie 2025 - Duurzame Energie & Tarieven | Contractvergelijkers</title>
-        <meta name="description" content="Eneco informatie 2025: 100% Nederlandse windenergie, tarieven, klantenservice en overstappen. Vergelijk Eneco via Contractvergelijkers." />
+        <title>Eneco Informatie 2025 - Duurzame Energie & Tarieven | Adviesneutraal</title>
+        <meta name="description" content="Eneco informatie 2025: 100% Nederlandse windenergie, tarieven, klantenservice en overstappen. Vergelijk Eneco via Adviesneutraal." />
         <meta name="keywords" content="Eneco tarieven 2025, Eneco groene energie, Eneco klantenservice, Eneco overstappen, duurzame energie" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -19,7 +19,7 @@ export default function Eneco() {
         {/* Navigation */}
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            ← Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -193,14 +193,14 @@ export default function Eneco() {
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <div className="mb-6">
               <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-                Contractvergelijkers
+                Adviesneutraal
               </Link>
               <p className="text-blue-200 mt-2">
                 Onafhankelijk energievergelijker • 200+ adviseurs • Gratis service
               </p>
             </div>
             <div className="border-t border-white/20 pt-6 text-blue-200">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
               <p className="mt-2">
                 <a href={`tel:${phoneNumber}`} className="text-green-400 hover:text-green-300 font-bold">
                   📞 {phoneNumber} - Ma-Vr 09:00-20:30

--- a/pages/providers/essent.tsx
+++ b/pages/providers/essent.tsx
@@ -8,8 +8,8 @@ export default function Essent() {
   return (
     <>
       <Head>
-        <title>Essent Informatie 2025 - Tarieven & Overstappen | Contractvergelijkers</title>
-        <meta name="description" content="Essent informatie 2025: Tarieven, klantenservice, overstappen en reviews. Grootste energieleverancier van Nederland. Vergelijk nu via Contractvergelijkers." />
+        <title>Essent Informatie 2025 - Tarieven & Overstappen | Adviesneutraal</title>
+        <meta name="description" content="Essent informatie 2025: Tarieven, klantenservice, overstappen en reviews. Grootste energieleverancier van Nederland. Vergelijk nu via Adviesneutraal." />
         <meta name="keywords" content="Essent tarieven 2025, Essent klantenservice, Essent overstappen, Essent contract, energieleverancier Essent" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -19,7 +19,7 @@ export default function Essent() {
         {/* Navigation */}
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -223,14 +223,14 @@ export default function Essent() {
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <div className="mb-6">
               <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-                Contractvergelijkers
+                Adviesneutraal
               </Link>
               <p className="text-blue-200 mt-2">
                 Onafhankelijk energievergelijker • 200+ adviseurs • Gratis service
               </p>
             </div>
             <div className="border-t border-white/20 pt-6 text-blue-200">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
               <p className="mt-2">
                 <a href={`tel:${phoneNumber}`} className="text-green-400 hover:text-green-300 font-bold">
                   📞 {phoneNumber} - Ma-Vr 09:00-20:30

--- a/pages/providers/greenchoice.tsx
+++ b/pages/providers/greenchoice.tsx
@@ -8,8 +8,8 @@ export default function Greenchoice() {
   return (
     <>
       <Head>
-        <title>Greenchoice Informatie 2025 - 100% Duurzame Energie | Contractvergelijkers</title>
-        <meta name="description" content="Greenchoice informatie 2025: Nederlandse groene energie pionier, 100% duurzame elektriciteit, tarieven en klantenservice. Vergelijk via Contractvergelijkers." />
+        <title>Greenchoice Informatie 2025 - Duurzame Energie | Adviesneutraal</title>
+        <meta name="description" content="Greenchoice informatie 2025: 100% duurzame elektriciteit, tarieven en klantenservice. Vergelijk via Adviesneutraal." />
         <meta name="keywords" content="Greenchoice tarieven 2025, groene energie, duurzame stroom, Greenchoice overstappen" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -18,7 +18,7 @@ export default function Greenchoice() {
       <main className="min-h-screen bg-gradient-to-br from-green-600 via-emerald-600 to-green-800">
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            ← Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -90,7 +90,7 @@ export default function Greenchoice() {
         <footer className="border-t border-white/20 mt-20">
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-              Contractvergelijkers
+              Adviesneutraal
             </Link>
             <p className="text-green-200 mt-4">
               <a href={`tel:${phoneNumber}`} className="text-green-300 hover:text-green-200 font-bold">

--- a/pages/providers/vandebron.tsx
+++ b/pages/providers/vandebron.tsx
@@ -8,8 +8,8 @@ export default function Vandebron() {
   return (
     <>
       <Head>
-        <title>Vandebron Informatie 2025 - 100% Nederlandse Duurzame Energie | Contractvergelijkers</title>
-        <meta name="description" content="Vandebron informatie 2025: 100% Nederlandse duurzame energie van lokale producenten. Tarieven, klantenservice en overstappen via Contractvergelijkers." />
+        <title>Vandebron Informatie 2025 - 100% Nederlandse Duurzame Energie | Adviesneutraal</title>
+        <meta name="description" content="Vandebron informatie 2025: 100% Nederlandse duurzame energie van lokale producenten. Tarieven, klantenservice en overstappen via Adviesneutraal." />
         <meta name="keywords" content="Vandebron tarieven 2025, lokale duurzame energie, Nederlandse producenten, Vandebron overstappen" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -18,7 +18,7 @@ export default function Vandebron() {
       <main className="min-h-screen bg-gradient-to-br from-green-600 via-blue-600 to-green-800">
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            ← Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -64,7 +64,7 @@ export default function Vandebron() {
         <footer className="border-t border-white/20 mt-20">
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-              Contractvergelijkers
+              Adviesneutraal
             </Link>
             <p className="text-blue-200 mt-4">
               <a href={`tel:${phoneNumber}`} className="text-green-400 hover:text-green-300 font-bold">

--- a/pages/providers/vattenfall.tsx
+++ b/pages/providers/vattenfall.tsx
@@ -8,8 +8,8 @@ export default function Vattenfall() {
   return (
     <>
       <Head>
-        <title>Vattenfall Informatie 2025 - Betrouwbare Energie & Tarieven | Contractvergelijkers</title>
-        <meta name="description" content="Vattenfall informatie 2025: Zweedse energiegigant, betrouwbare elektriciteit en gas, tarieven en klantenservice. Vergelijk via Contractvergelijkers." />
+        <title>Vattenfall Informatie 2025 - Betrouwbare Energie & Tarieven | Adviesneutraal</title>
+        <meta name="description" content="Vattenfall informatie 2025: Zweedse energiegigant, betrouwbare elektriciteit en gas, tarieven en klantenservice. Vergelijk via Adviesneutraal." />
         <meta name="keywords" content="Vattenfall tarieven 2025, Vattenfall klantenservice, Vattenfall overstappen, Zweedse energieleverancier" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -18,7 +18,7 @@ export default function Vattenfall() {
       <main className="min-h-screen bg-gradient-to-br from-blue-600 via-green-600 to-blue-800">
         <nav className="flex justify-between items-center p-6 max-w-7xl mx-auto">
           <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-            ← Contractvergelijkers
+            ← Adviesneutraal
           </Link>
           <a href={`tel:${phoneNumber}`} className="bg-green-400 text-black px-4 py-2 rounded-lg hover:bg-green-300 transition-colors font-bold text-lg shadow-lg">
             📞 {phoneNumber}
@@ -139,7 +139,7 @@ export default function Vattenfall() {
         <footer className="border-t border-white/20 mt-20">
           <div className="max-w-7xl mx-auto px-6 py-8 text-center">
             <Link href="/" className="text-white text-2xl font-bold hover:text-green-200 transition-colors">
-              Contractvergelijkers
+              Adviesneutraal
             </Link>
             <p className="text-blue-200 mt-4">
               <a href={`tel:${phoneNumber}`} className="text-green-400 hover:text-green-300 font-bold">

--- a/pages/vergelijker-1.tsx
+++ b/pages/vergelijker-1.tsx
@@ -53,7 +53,7 @@ export default function Vergelijker1() {
   return (
     <>
       <Head>
-        <title>Persoonlijke Energieadviseur - Gratis Consultatie | Contractvergelijkers</title>
+        <title>Persoonlijke Energieadviseur - Gratis Consultatie | Adviesneutraal</title>
         <meta name="description" content="Vergelijk alle energieleveranciers in Nederland en ontdek binnen 2 minuten hoeveel je kunt besparen. 100% Gratis advies." />
         <meta name="keywords" content="energie vergelijken, energierekening besparen, goedkoopste energie, energieleverancier vergelijken" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -96,7 +96,7 @@ export default function Vergelijker1() {
                   <div className="w-10 h-10 bg-teal-600 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-gray-900">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-gray-900">Adviesneutraal</span>
                 </div>
               </Link>
               <div className="flex items-center space-x-4">
@@ -157,7 +157,7 @@ export default function Vergelijker1() {
               </a>
               
               <p className="text-sm text-gray-600">
-                contractvergelijkers.nl
+                adviesneutraal.nl
               </p>
             </div>
 
@@ -720,7 +720,7 @@ export default function Vergelijker1() {
             </a>
             
             <p className="text-green-100 text-sm mt-4">
-              contractvergelijkers.nl
+              adviesneutraal.nl
             </p>
           </div>
         </section>
@@ -730,7 +730,7 @@ export default function Vergelijker1() {
           <div className="max-w-6xl mx-auto px-6">
             <div className="grid md:grid-cols-3 gap-8">
               <div>
-                <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
+                <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
                 <p className="text-gray-300 mb-4">
                   24/7 energieklantenservice voor directe hulp en gemiddeld €700 besparing per jaar.
                 </p>
@@ -769,7 +769,7 @@ export default function Vergelijker1() {
             </div>
 
             <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
           </div>
         </footer>

--- a/pages/vergelijker-2.tsx
+++ b/pages/vergelijker-2.tsx
@@ -53,8 +53,8 @@ export default function Vergelijker2() {
   return (
     <>
       <Head>
-        <title>Bespaar en Vind Klantenservice | Contractvergelijkers Advieslijn</title>
-        <meta name="description" content="Klantenservice Contractvergelijkers: onafhankelijk advies en tarieven vergelijken. Wij helpen met vragen en overstappen. Bel direct." />
+        <title>Bespaar en Vind Klantenservice | Adviesneutraal Advieslijn</title>
+        <meta name="description" content="Klantenservice Adviesneutraal: onafhankelijk advies en tarieven vergelijken. Wij helpen met vragen en overstappen. Bel direct." />
         <meta name="keywords" content="klantenservice energie, energieleverancier telefoonnummer, energie vergelijken, onafhankelijk advies, overstappen energie" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -96,7 +96,7 @@ export default function Vergelijker2() {
                   <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-gray-900">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-gray-900">Adviesneutraal</span>
                 </div>
               </Link>
               <div className="flex items-center space-x-4">
@@ -114,7 +114,7 @@ export default function Vergelijker2() {
           <div className="max-w-4xl mx-auto px-6 text-center">
             <div className="mb-8">
               <h1 className="text-3xl md:text-5xl font-bold text-gray-900 mb-4 leading-tight">
-                <span className="text-blue-600">Klantenservice Contractvergelijkers</span>
+                <span className="text-blue-600">Klantenservice Adviesneutraal</span>
                 <br />
                 <span className="text-2xl md:text-3xl text-gray-700">Direct hulp & onafhankelijk energie-advies</span>
               </h1>
@@ -152,7 +152,7 @@ export default function Vergelijker2() {
 
             {/* Main CTA */}
             <div className="bg-blue-600 text-white p-8 rounded-xl mb-8">
-              <h2 className="text-2xl font-bold mb-4">Direct contact met Contractvergelijkers Klantenservice</h2>
+              <h2 className="text-2xl font-bold mb-4">Direct contact met Adviesneutraal Klantenservice</h2>
               <p className="text-blue-100 mb-6">
                 Bel voor onafhankelijk energie-advies en vergelijking van tarieven. Wij zijn geen onderdeel van energieleveranciers en behandelen geen klantdossiers van providers.
               </p>
@@ -533,7 +533,7 @@ export default function Vergelijker2() {
               📞 Heeft u Hulp Nodig?
             </h2>
             <p className="text-blue-100 text-lg mb-8">
-              Onze klantenservice van Contractvergelijkers staat klaar met onafhankelijk advies over uw energievraag.
+              Onze klantenservice van Adviesneutraal staat klaar met onafhankelijk advies over uw energievraag.
             </p>
             
             <a 
@@ -545,7 +545,7 @@ export default function Vergelijker2() {
             </a>
             
             <p className="text-blue-100 text-sm mt-4">
-              Wij zijn de klantenservice van contractvergelijkers.nl (onafhankelijke advieslijn) en niet de officiële klantenservice van energieleveranciers. Voor contract- en factuurzaken bij uw huidige provider kunt u rechtstreeks bij uw leverancier terecht.
+              Wij zijn de klantenservice van adviesneutraal.nl (onafhankelijke advieslijn) en niet de officiële klantenservice van energieleveranciers. Voor contract- en factuurzaken bij uw huidige provider kunt u rechtstreeks bij uw leverancier terecht.
             </p>
           </div>
         </section>
@@ -555,7 +555,7 @@ export default function Vergelijker2() {
           <div className="max-w-6xl mx-auto px-6">
             <div className="grid md:grid-cols-3 gap-8">
               <div>
-                <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
+                <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
                 <p className="text-gray-300 mb-4">
                   Onafhankelijk energievergelijkingsplatform. Gemiddeld €700 besparing per jaar.
                 </p>
@@ -594,7 +594,7 @@ export default function Vergelijker2() {
             </div>
 
             <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
           </div>
         </footer>

--- a/pages/vergelijker-3.tsx
+++ b/pages/vergelijker-3.tsx
@@ -53,7 +53,7 @@ export default function Vergelijker3() {
   return (
     <>
       <Head>
-        <title>Bespaar Tot €600 Per Jaar op je Energierekening! | Contractvergelijkers</title>
+        <title>Bespaar Tot €600 Per Jaar op je Energierekening! | Adviesneutraal</title>
         <meta name="description" content="Vergelijk alle energieleveranciers in Nederland en ontdek binnen 2 minuten hoeveel je kunt besparen. 100% Gratis advies." />
         <meta name="keywords" content="energie vergelijken, energierekening besparen, goedkoopste energie, energieleverancier vergelijken" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -96,7 +96,7 @@ export default function Vergelijker3() {
                   <div className="w-10 h-10 bg-orange-600 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-gray-900">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-gray-900">Adviesneutraal</span>
                 </div>
               </Link>
               <div className="flex items-center space-x-4">
@@ -561,7 +561,7 @@ export default function Vergelijker3() {
             </a>
             
             <p className="text-orange-100 text-sm mt-4">
-              contractvergelijkers.nl
+              adviesneutraal.nl
             </p>
           </div>
         </section>
@@ -571,7 +571,7 @@ export default function Vergelijker3() {
           <div className="max-w-6xl mx-auto px-6">
             <div className="grid md:grid-cols-3 gap-8">
               <div>
-                <img src="/logos/contractvergelijkers-logo.png" alt="Contractvergelijkers" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
+                <img src="/logos/contractvergelijkers-logo.png" alt="Adviesneutraal" className="h-12 md:h-14 w-auto mb-4 brightness-0 invert" />
                 <p className="text-gray-300 mb-4">
                   Nederland's slimste energieoplossingen. 15+ jaar expertise, 50.000+ tevreden klanten.
                 </p>
@@ -610,7 +610,7 @@ export default function Vergelijker3() {
             </div>
 
             <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden. | BTW: NL123456789B01</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden. | BTW: NL123456789B01</p>
             </div>
           </div>
         </footer>

--- a/pages/vergelijker.tsx
+++ b/pages/vergelijker.tsx
@@ -54,7 +54,7 @@ export default function Vergelijker() {
   return (
     <>
       <Head>
-        <title>Bespaar Tot €600 Per Jaar op je Energierekening! | Contractvergelijkers</title>
+        <title>Bespaar Tot €600 Per Jaar op je Energierekening! | Adviesneutraal</title>
         <meta name="description" content="Vergelijk alle energieleveranciers in Nederland en ontdek binnen 2 minuten hoeveel je kunt besparen. 100% Gratis advies." />
         <meta name="keywords" content="energie vergelijken, energierekening besparen, goedkoopste energie, energieleverancier vergelijken" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -97,7 +97,7 @@ export default function Vergelijker() {
                   <div className="w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-gray-900">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-gray-900">Adviesneutraal</span>
                 </div>
               </Link>
               <div className="flex items-center space-x-4">
@@ -159,7 +159,7 @@ export default function Vergelijker() {
               </a>
               
               <p className="text-sm text-gray-600">
-                contractvergelijkers.nl
+                adviesneutraal.nl
               </p>
             </div>
 
@@ -429,7 +429,7 @@ export default function Vergelijker() {
             </a>
             
             <p className="text-green-100 text-sm mt-4">
-              contractvergelijkers.nl
+              adviesneutraal.nl
             </p>
           </div>
         </section>
@@ -443,10 +443,10 @@ export default function Vergelijker() {
                   <div className="w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center">
                     <span className="text-white text-xl font-bold">⚡</span>
                   </div>
-                  <span className="text-2xl font-bold text-white">Contractvergelijkers</span>
+                  <span className="text-2xl font-bold text-white">Adviesneutraal</span>
                 </div>
                 <p className="text-gray-300 mb-4">
-                  De meest betrouwbare contractvergelijkers van Nederland.
+                  Onafhankelijk energie-advies voor heel Nederland.
                 </p>
               </div>
               <div>
@@ -466,7 +466,7 @@ export default function Vergelijker() {
               </div>
             </div>
             <div className="border-t border-gray-700 mt-8 pt-8 text-center text-gray-400">
-              <p>&copy; 2025 Contractvergelijkers. Alle rechten voorbehouden.</p>
+              <p>&copy; 2025 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
           </div>
         </footer>

--- a/robots.txt
+++ b/robots.txt
@@ -1,24 +1,13 @@
-User-agent: *
-Allow: /
+# robots.txt for Next.js
 
 # Sitemap
-Sitemap: https://contractvergelijkers.nl/sitemap.xml
+Sitemap: https://adviesneutraal.nl/sitemap.xml
 
 # Allow crawling of CSS and JS files
-Allow: /styles.css
-Allow: /script.js
+User-agent: *
+Allow: /*.js$
+Allow: /*.css$
 
-# Allow all HTML pages
-Allow: /index.html
-Allow: /essent-klantenservice.html
-Allow: /eneco-klantenservice.html
-Allow: /vattenfall-klantenservice.html
-Allow: /budget-energie-klantenservice.html
-
-# Disallow any admin or private directories (if they exist)
+# Disallow sensitive paths
+Disallow: /api/
 Disallow: /admin/
-Disallow: /private/
-Disallow: /.git/
-
-# Crawl-delay (optional, for large sites)
-# Crawl-delay: 1

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,71 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <!-- Homepage -->
     <url>
-        <loc>https://contractvergelijkers.nl/</loc>
+        <loc>https://adviesneutraal.nl/</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>weekly</changefreq>
-        <priority>1.0</priority>
     </url>
 
     <!-- Essent Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/essent-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/essent-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.9</priority>
     </url>
 
     <!-- Eneco Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/eneco-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/eneco-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.9</priority>
     </url>
 
     <!-- Vattenfall Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/vattenfall-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/vattenfall-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.9</priority>
     </url>
 
     <!-- Budget Energie Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/budget-energie-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/budget-energie-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.9</priority>
     </url>
 
     <!-- Greenchoice Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/greenchoice-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/greenchoice-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
     </url>
 
     <!-- NUON Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/nuon-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/nuon-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
     </url>
 
     <!-- Oxxio Customer Service Page -->
     <url>
-        <loc>https://contractvergelijkers.nl/oxxio-klantenservice.html</loc>
+        <loc>https://adviesneutraal.nl/oxxio-klantenservice.html</loc>
         <lastmod>2024-01-01</lastmod>
         <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
     </url>
-
 </urlset>

--- a/static-backup/eneco-klantenservice.html
+++ b/static-backup/eneco-klantenservice.html
@@ -5,16 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Zoekt u Eneco klantenservice? Bel direct +31 85 087 2183 voor hulp bij uw Eneco energiecontract. Vergelijk ook andere duurzame aanbieders!">
     <meta name="keywords" content="Eneco klantenservice, Eneco telefoonnummer, Eneco contact, groene energie vergelijken, Eneco tarieven">
-    <title>Eneco Klantenservice | Direct Bereikbaar +31 85 087 2183 | Contractvergelijkers</title>
+    <title>Eneco Klantenservice | Direct Bereikbaar +31 85 087 2183 | Adviesneutraal</title>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://contractvergelijkers.nl/eneco-klantenservice">
+    <meta property="og:url" content="https://adviesneutraal.nl/eneco-klantenservice">
     <meta property="og:title" content="Eneco Klantenservice | Direct Bereikbaar +31 85 087 2183">
     <meta property="og:description" content="Zoekt u Eneco klantenservice? Bel direct +31 85 087 2183 voor hulp bij uw Eneco energiecontract. Vergelijk ook andere duurzame aanbieders!">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://contractvergelijkers.nl/eneco-klantenservice">
+    <link rel="canonical" href="https://adviesneutraal.nl/eneco-klantenservice">
     
     <!-- CSS -->
     <link rel="stylesheet" href="styles.css">
@@ -30,7 +30,7 @@
     <header class="header">
         <nav class="nav container">
             <div class="nav__brand">
-                <h1><a href="/" style="color: inherit; text-decoration: none;">Contractvergelijkers</a></h1>
+                <h1><a href="/" style="color: inherit; text-decoration: none;">Adviesneutraal</a></h1>
             </div>
             <div class="nav__menu">
                 <a href="/" class="nav__link">Home</a>
@@ -253,7 +253,7 @@
         <div class="container">
             <div class="footer__content">
                 <div class="footer__section">
-                    <h3>Contractvergelijkers</h3>
+                    <h3>Adviesneutraal</h3>
                     <p>Specialist in duurzame energie vergelijking, inclusief Eneco en alle andere groene leveranciers.</p>
                     <div class="footer__phone">
                         <i class="fas fa-phone"></i>
@@ -280,7 +280,7 @@
                 </div>
             </div>
             <div class="footer__bottom">
-                <p>&copy; 2024 Contractvergelijkers. Alle rechten voorbehouden.</p>
+                <p>&copy; 2024 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
         </div>
     </footer>

--- a/static-backup/essent-klantenservice.html
+++ b/static-backup/essent-klantenservice.html
@@ -5,16 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Zoekt u Essent klantenservice? Bel direct +31 85 087 2183 voor hulp bij uw Essent energiecontract. Vergelijk ook andere aanbieders en bespaar!">
     <meta name="keywords" content="Essent klantenservice, Essent telefoonnummer, Essent contact, energie vergelijken, Essent tarieven">
-    <title>Essent Klantenservice | Direct Bereikbaar +31 85 087 2183 | Contractvergelijkers</title>
+    <title>Essent Klantenservice | Direct Bereikbaar +31 85 087 2183 | Adviesneutraal</title>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://contractvergelijkers.nl/essent-klantenservice">
+    <meta property="og:url" content="https://adviesneutraal.nl/essent-klantenservice">
     <meta property="og:title" content="Essent Klantenservice | Direct Bereikbaar +31 85 087 2183">
     <meta property="og:description" content="Zoekt u Essent klantenservice? Bel direct +31 85 087 2183 voor hulp bij uw Essent energiecontract. Vergelijk ook andere aanbieders en bespaar!">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://contractvergelijkers.nl/essent-klantenservice">
+    <link rel="canonical" href="https://adviesneutraal.nl/essent-klantenservice">
     
     <!-- CSS -->
     <link rel="stylesheet" href="styles.css">
@@ -30,7 +30,7 @@
     <header class="header">
         <nav class="nav container">
             <div class="nav__brand">
-                <h1><a href="/" style="color: inherit; text-decoration: none;">Contractvergelijkers</a></h1>
+                <h1><a href="/" style="color: inherit; text-decoration: none;">Adviesneutraal</a></h1>
             </div>
             <div class="nav__menu">
                 <a href="/" class="nav__link">Home</a>
@@ -228,8 +228,8 @@
         <div class="container">
             <div class="footer__content">
                 <div class="footer__section">
-                    <h3>Contractvergelijkers</h3>
-                    <p>Onafhankelijk energievergelijkingsplatform voor alle Nederlandse leveranciers, inclusief Essent.</p>
+                    <h3>Adviesneutraal</h3>
+                    <p>Onafhankelijk energie-adviesplatform voor alle Nederlandse leveranciers, inclusief Essent.</p>
                     <div class="footer__phone">
                         <i class="fas fa-phone"></i>
                         <a href="tel:+31850872183">+31 85 087 2183</a>
@@ -255,7 +255,7 @@
                 </div>
             </div>
             <div class="footer__bottom">
-                <p>&copy; 2024 Contractvergelijkers. Alle rechten voorbehouden.</p>
+                <p>&copy; 2024 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
         </div>
     </footer>

--- a/static-backup/index.html
+++ b/static-backup/index.html
@@ -5,12 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Zoekt u klantenservice van uw energieleverancier? Wij vergelijken ALLE energiecontracten in Nederland. Bel direct: +31 85 087 2183">
     <meta name="keywords" content="klantenservice energie, energieleverancier telefoonnummer, energie vergelijken, Essent klantenservice, Eneco klantenservice, Vattenfall klantenservice">
-    <title>Contractvergelijkers - Klantenservice Alle Energieleveranciers | +31 85 087 2183</title>
+    <title>Adviesneutraal - Klantenservice Alle Energieleveranciers | +31 85 087 2183</title>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://contractvergelijkers.nl/">
-    <meta property="og:title" content="Contractvergelijkers - Klantenservice Alle Energieleveranciers">
+    <meta property="og:url" content="https://adviesneutraal.nl/">
+    <meta property="og:title" content="Adviesneutraal - Klantenservice Alle Energieleveranciers">
     <meta property="og:description" content="Zoekt u klantenservice van uw energieleverancier? Wij vergelijken ALLE energiecontracten in Nederland. Bel direct: +31 85 087 2183">
     
     <!-- Favicon -->
@@ -30,7 +30,7 @@
     <header class="header">
         <nav class="nav container">
             <div class="nav__brand">
-                <h1>Contractvergelijkers</h1>
+                <h1>Adviesneutraal</h1>
             </div>
             <div class="nav__menu">
                 <a href="#home" class="nav__link">Home</a>
@@ -81,7 +81,7 @@
     <section class="trust">
         <div class="container">
             <div class="trust__content">
-                <h3>Waarom kiezen voor Contractvergelijkers?</h3>
+                <h3>Waarom kiezen voor Adviesneutraal?</h3>
                 <div class="trust__grid">
                     <div class="trust__item">
                         <i class="fas fa-shield-alt"></i>
@@ -188,7 +188,7 @@
         <div class="container">
             <div class="about__content">
                 <div class="about__text">
-                    <h2>Over Contractvergelijkers</h2>
+                    <h2>Over Adviesneutraal</h2>
                     <p>
                         Wij zijn het grootste onafhankelijke energievergelijkingsplatform van Nederland. 
                         Met ons team van 200+ ervaren energieadviseurs helpen wij dagelijks duizenden 
@@ -280,8 +280,8 @@
         <div class="container">
             <div class="footer__content">
                 <div class="footer__section">
-                    <h3>Contractvergelijkers</h3>
-                    <p>Het grootste onafhankelijke energievergelijkingsplatform van Nederland.</p>
+                    <h3>Adviesneutraal</h3>
+                    <p>Het grootste onafhankelijke energie-adviesplatform van Nederland.</p>
                     <div class="footer__phone">
                         <i class="fas fa-phone"></i>
                         <a href="tel:+31850872183">+31 85 087 2183</a>
@@ -306,7 +306,7 @@
                 </div>
             </div>
             <div class="footer__bottom">
-                <p>&copy; 2024 Contractvergelijkers. Alle rechten voorbehouden.</p>
+                <p>&copy; 2024 Adviesneutraal. Alle rechten voorbehouden.</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Rebrand 'Contractvergelijkers' to 'Adviesneutraal' and enhance homepage content for compliance.

---
<a href="https://cursor.com/background-agent?bcId=bc-cafc2f16-fa94-4431-b2fe-367578511fb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cafc2f16-fa94-4431-b2fe-367578511fb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

